### PR TITLE
use t.error instead of t.pass

### DIFF
--- a/test/mime.test.js
+++ b/test/mime.test.js
@@ -36,7 +36,7 @@ test('send.mime', function (t) {
       request(createServer({ root: fixtures }))
         .get('/no_ext')
         .expect('Content-Type', 'text/plain; charset=UTF-8')
-        .expect(200, () => t.pass())
+        .expect(200, err => t.error(err))
     })
 
     t.test('should not add Content-Type for undefined default', function (t) {
@@ -46,7 +46,7 @@ test('send.mime', function (t) {
       request(createServer({ root: fixtures }))
         .get('/no_ext')
         .expect(shouldNotHaveHeader('Content-Type', t))
-        .expect(200, () => t.pass())
+        .expect(200, err => t.error(err))
     })
 
     t.test('should return Content-Type without charset', function (t) {
@@ -55,7 +55,7 @@ test('send.mime', function (t) {
       request(createServer({ root: fixtures }))
         .get('/images/node-js.png')
         .expect('Content-Type', 'image/png')
-        .expect(200, () => t.pass())
+        .expect(200, err => t.error(err))
     })
   })
 })

--- a/test/send-pipe.test.js
+++ b/test/send-pipe.test.js
@@ -34,7 +34,7 @@ test('send(file).pipe(res)', function (t) {
     request(app)
       .get('/name.txt')
       .expect('Content-Length', '4')
-      .expect(200, 'tobi', () => t.pass())
+      .expect(200, 'tobi', err => t.error(err))
   })
 
   t.test('should stream a zero-length file', function (t) {
@@ -54,7 +54,7 @@ test('send(file).pipe(res)', function (t) {
     request(app)
       .get('/empty.txt')
       .expect('Content-Length', '0')
-      .expect(200, '', () => t.pass())
+      .expect(200, '', err => t.error(err))
   })
 
   t.test('should decode the given path as a URI', function (t) {
@@ -73,7 +73,7 @@ test('send(file).pipe(res)', function (t) {
 
     request(app)
       .get('/some%20thing.txt')
-      .expect(200, 'hey', () => t.pass())
+      .expect(200, 'hey', err => t.error(err))
   })
 
   t.test('should serve files with dots in name', function (t) {
@@ -92,7 +92,7 @@ test('send(file).pipe(res)', function (t) {
 
     request(app)
       .get('/do..ts.txt')
-      .expect(200, '...', () => t.pass())
+      .expect(200, '...', err => t.error(err))
   })
 
   t.test('should treat a malformed URI as a bad request', function (t) {
@@ -111,7 +111,7 @@ test('send(file).pipe(res)', function (t) {
 
     request(app)
       .get('/some%99thing.txt')
-      .expect(400, 'Bad Request', () => t.pass())
+      .expect(400, 'Bad Request', err => t.error(err))
   })
 
   t.test('should 400 on NULL bytes', function (t) {
@@ -130,7 +130,7 @@ test('send(file).pipe(res)', function (t) {
 
     request(app)
       .get('/some%00thing.txt')
-      .expect(400, 'Bad Request', () => t.pass())
+      .expect(400, 'Bad Request', err => t.error(err))
   })
 
   t.test('should treat an ENAMETOOLONG as a 404', function (t) {
@@ -150,7 +150,7 @@ test('send(file).pipe(res)', function (t) {
     const path = Array(100).join('foobar')
     request(app)
       .get('/' + path)
-      .expect(404, () => t.pass())
+      .expect(404, err => t.error(err))
   })
 
   t.test('should handle headers already sent error', function (t) {
@@ -164,7 +164,7 @@ test('send(file).pipe(res)', function (t) {
     })
     request(app)
       .get('/name.txt')
-      .expect(200, '0 - Can\'t set headers after they are sent.', () => t.pass())
+      .expect(200, '0 - Can\'t set headers after they are sent.', err => t.error(err))
   })
 
   t.test('should support HEAD', function (t) {
@@ -186,7 +186,7 @@ test('send(file).pipe(res)', function (t) {
       .expect(200)
       .expect('Content-Length', '4')
       .expect(shouldNotHaveBody(t))
-      .end(() => t.pass())
+      .end(err => t.error(err))
   })
 
   t.test('should add an ETag header field', function (t) {
@@ -206,7 +206,7 @@ test('send(file).pipe(res)', function (t) {
     request(app)
       .get('/name.txt')
       .expect('etag', /^W\/"[^"]+"$/)
-      .end(() => t.pass())
+      .end(err => t.error(err))
   })
 
   t.test('should add a Date header field', function (t) {
@@ -225,7 +225,7 @@ test('send(file).pipe(res)', function (t) {
 
     request(app)
       .get('/name.txt')
-      .expect('date', dateRegExp, () => t.pass())
+      .expect('date', dateRegExp, err => t.error(err))
   })
 
   t.test('should add a Last-Modified header field', function (t) {
@@ -244,7 +244,7 @@ test('send(file).pipe(res)', function (t) {
 
     request(app)
       .get('/name.txt')
-      .expect('last-modified', dateRegExp, () => t.pass())
+      .expect('last-modified', dateRegExp, err => t.error(err))
   })
 
   t.test('should add a Accept-Ranges header field', function (t) {
@@ -263,7 +263,7 @@ test('send(file).pipe(res)', function (t) {
 
     request(app)
       .get('/name.txt')
-      .expect('Accept-Ranges', 'bytes', () => t.pass())
+      .expect('Accept-Ranges', 'bytes', err => t.error(err))
   })
 
   t.test('should 404 if the file does not exist', function (t) {
@@ -282,7 +282,7 @@ test('send(file).pipe(res)', function (t) {
 
     request(app)
       .get('/meow')
-      .expect(404, 'Not Found', () => t.pass())
+      .expect(404, 'Not Found', err => t.error(err))
   })
 
   t.test('should emit ENOENT if the file does not exist', function (t) {
@@ -296,7 +296,7 @@ test('send(file).pipe(res)', function (t) {
 
     request(app)
       .get('/meow')
-      .expect(200, '404 ENOENT', () => t.pass())
+      .expect(200, '404 ENOENT', err => t.error(err))
   })
 
   t.test('should not override content-type', function (t) {
@@ -308,7 +308,7 @@ test('send(file).pipe(res)', function (t) {
     })
     request(app)
       .get('/name.txt')
-      .expect('Content-Type', 'application/x-custom', () => t.pass())
+      .expect('Content-Type', 'application/x-custom', err => t.error(err))
   })
 
   t.test('should set Content-Type via mime map', function (t) {
@@ -333,7 +333,7 @@ test('send(file).pipe(res)', function (t) {
         request(app)
           .get('/tobi.html')
           .expect('Content-Type', 'text/html; charset=UTF-8')
-          .expect(200, () => t.pass())
+          .expect(200, err => t.error(err))
       })
   })
 
@@ -354,7 +354,7 @@ test('send(file).pipe(res)', function (t) {
 
     request(app)
       .get('/name.txt')
-      .expect(404, () => t.pass())
+      .expect(404, err => t.error(err))
   })
 
   t.test('should 500 on file stream error', function (t) {
@@ -373,14 +373,14 @@ test('send(file).pipe(res)', function (t) {
 
     request(app)
       .get('/name.txt')
-      .expect(500, () => t.pass())
+      .expect(500, err => t.error(err))
   })
 
   t.test('"headers" event', function (t) {
     t.plan(7)
     t.test('should fire when sending file', function (t) {
       t.plan(1)
-      const cb = after(2, () => t.pass())
+      const cb = after(2, err => t.error(err))
       const server = http.createServer(function (req, res) {
         send(req, req.url, { root: fixtures })
           .on('headers', function () { cb() })
@@ -394,7 +394,7 @@ test('send(file).pipe(res)', function (t) {
 
     t.test('should not fire on 404', function (t) {
       t.plan(1)
-      const cb = after(1, () => t.pass())
+      const cb = after(1, err => t.error(err))
       const server = http.createServer(function (req, res) {
         send(req, req.url, { root: fixtures })
           .on('headers', function () { cb() })
@@ -408,7 +408,7 @@ test('send(file).pipe(res)', function (t) {
 
     t.test('should fire on index', function (t) {
       t.plan(1)
-      const cb = after(2, () => t.pass())
+      const cb = after(2, err => t.error(err))
       const server = http.createServer(function (req, res) {
         send(req, req.url, { root: fixtures })
           .on('headers', function () { cb() })
@@ -422,7 +422,7 @@ test('send(file).pipe(res)', function (t) {
 
     t.test('should not fire on redirect', function (t) {
       t.plan(1)
-      const cb = after(1, () => t.pass())
+      const cb = after(1, err => t.error(err))
       const server = http.createServer(function (req, res) {
         send(req, req.url, { root: fixtures })
           .on('headers', function () { cb() })
@@ -436,7 +436,7 @@ test('send(file).pipe(res)', function (t) {
 
     t.test('should provide path', function (t) {
       t.plan(3)
-      const cb = after(2, () => t.pass())
+      const cb = after(2, err => t.error(err))
       const server = http.createServer(function (req, res) {
         send(req, req.url, { root: fixtures })
           .on('headers', onHeaders)
@@ -456,7 +456,7 @@ test('send(file).pipe(res)', function (t) {
 
     t.test('should provide stat', function (t) {
       t.plan(4)
-      const cb = after(2, () => t.pass())
+      const cb = after(2, err => t.error(err))
       const server = http.createServer(function (req, res) {
         send(req, req.url, { root: fixtures })
           .on('headers', onHeaders)
@@ -498,7 +498,7 @@ test('send(file).pipe(res)', function (t) {
         .expect('ETag', 'W/"everything"')
         .expect('X-Created', dateRegExp)
         .expect('tobi')
-        .end(() => t.pass())
+        .end(err => t.error(err))
     })
   })
 
@@ -520,7 +520,7 @@ test('send(file).pipe(res)', function (t) {
 
       request(server)
         .get('/pets')
-        .expect(400, 'No directory for you', () => t.pass())
+        .expect(400, 'No directory for you', err => t.error(err))
     })
 
     t.test('should be called with path', function (t) {
@@ -537,7 +537,7 @@ test('send(file).pipe(res)', function (t) {
 
       request(server)
         .get('/pets')
-        .expect(200, path.normalize(path.join(fixtures, 'pets')), () => t.pass())
+        .expect(200, path.normalize(path.join(fixtures, 'pets')), err => t.error(err))
     })
   })
 
@@ -550,7 +550,7 @@ test('send(file).pipe(res)', function (t) {
       request(createServer({ root: fixtures }))
         .get('/pets')
         .expect('Location', '/pets/')
-        .expect(301, () => t.pass())
+        .expect(301, err => t.error(err))
     })
 
     t.test('should respond with an HTML redirect', function (t) {
@@ -560,7 +560,7 @@ test('send(file).pipe(res)', function (t) {
         .get('/pets')
         .expect('Location', '/pets/')
         .expect('Content-Type', /html/)
-        .expect(301, />Redirecting to <a href="\/pets\/">\/pets\/<\/a></, () => t.pass())
+        .expect(301, />Redirecting to <a href="\/pets\/">\/pets\/<\/a></, err => t.error(err))
     })
 
     t.test('should respond with default Content-Security-Policy', function (t) {
@@ -570,7 +570,7 @@ test('send(file).pipe(res)', function (t) {
         .get('/pets')
         .expect('Location', '/pets/')
         .expect('Content-Security-Policy', "default-src 'none'")
-        .expect(301, () => t.pass())
+        .expect(301, err => t.error(err))
     })
 
     t.test('should not redirect to protocol-relative locations', function (t) {
@@ -579,7 +579,7 @@ test('send(file).pipe(res)', function (t) {
       request(createServer({ root: fixtures }))
         .get('//pets')
         .expect('Location', '/pets/')
-        .expect(301, () => t.pass())
+        .expect(301, err => t.error(err))
     })
 
     t.test('should respond with an HTML redirect', function (t) {
@@ -594,7 +594,7 @@ test('send(file).pipe(res)', function (t) {
         .get('/snow')
         .expect('Location', '/snow%20%E2%98%83/')
         .expect('Content-Type', /html/)
-        .expect(301, />Redirecting to <a href="\/snow%20%E2%98%83\/">\/snow%20%E2%98%83\/<\/a></, () => t.pass())
+        .expect(301, />Redirecting to <a href="\/snow%20%E2%98%83\/">\/snow%20%E2%98%83\/<\/a></, err => t.error(err))
     })
   })
 
@@ -606,7 +606,7 @@ test('send(file).pipe(res)', function (t) {
 
       request(createServer({ root: fixtures }))
         .get('/foobar')
-        .expect(404, />Not Found</, () => t.pass())
+        .expect(404, />Not Found</, err => t.error(err))
     })
 
     t.test('should respond with default Content-Security-Policy', function (t) {
@@ -615,7 +615,7 @@ test('send(file).pipe(res)', function (t) {
       request(createServer({ root: fixtures }))
         .get('/foobar')
         .expect('Content-Security-Policy', "default-src 'none'")
-        .expect(404, () => t.pass())
+        .expect(404, err => t.error(err))
     })
 
     t.test('should remove all previously-set headers', function (t) {
@@ -628,7 +628,7 @@ test('send(file).pipe(res)', function (t) {
       request(server)
         .get('/foobar')
         .expect(shouldNotHaveHeader('X-Foo', t))
-        .expect(404, () => t.pass())
+        .expect(404, err => t.error(err))
     })
   })
 
@@ -656,7 +656,7 @@ test('send(file).pipe(res)', function (t) {
             .expect(shouldNotHaveHeader('Content-Type', t))
             .expect('Content-Location', 'http://localhost/name.txt')
             .expect('Contents', 'foo')
-            .expect(304, () => t.pass())
+            .expect(304, err => t.error(err))
         })
     })
 
@@ -679,7 +679,7 @@ test('send(file).pipe(res)', function (t) {
             .expect(shouldNotHaveHeader('Content-Type', t))
             .expect('Content-Location', 'http://localhost/name.txt')
             .expect('Content-Security-Policy', 'default-src \'self\'')
-            .expect(304, () => t.pass())
+            .expect(304, err => t.error(err))
         })
     })
 
@@ -703,7 +703,7 @@ test('send(file).pipe(res)', function (t) {
         request(app)
           .get('/name.txt')
           .set('If-Match', '*')
-          .expect(200, () => t.pass())
+          .expect(200, err => t.error(err))
       })
 
       t.test('should respond with 412 when ETag unmatched', function (t) {
@@ -723,7 +723,7 @@ test('send(file).pipe(res)', function (t) {
         request(app)
           .get('/name.txt')
           .set('If-Match', ' "foo",, "bar" ,')
-          .expect(412, () => t.pass())
+          .expect(412, err => t.error(err))
       })
 
       t.test('should respond with 200 when ETag matched', function (t) {
@@ -747,7 +747,7 @@ test('send(file).pipe(res)', function (t) {
             request(app)
               .get('/name.txt')
               .set('If-Match', '"foo", "bar", ' + res.headers.etag)
-              .expect(200, () => t.pass())
+              .expect(200, err => t.error(err))
           })
       })
     })
@@ -776,7 +776,7 @@ test('send(file).pipe(res)', function (t) {
             request(app)
               .get('/name.txt')
               .set('If-Modified-Since', res.headers['last-modified'])
-              .expect(304, () => t.pass())
+              .expect(304, err => t.error(err))
           })
       })
 
@@ -803,7 +803,7 @@ test('send(file).pipe(res)', function (t) {
             request(app)
               .get('/name.txt')
               .set('If-Modified-Since', date.toUTCString())
-              .expect(200, 'tobi', () => t.pass())
+              .expect(200, 'tobi', err => t.error(err))
           })
       })
     })
@@ -832,7 +832,7 @@ test('send(file).pipe(res)', function (t) {
             request(app)
               .get('/name.txt')
               .set('If-None-Match', res.headers.etag)
-              .expect(304, () => t.pass())
+              .expect(304, err => t.error(err))
           })
       })
 
@@ -857,7 +857,7 @@ test('send(file).pipe(res)', function (t) {
             request(app)
               .get('/name.txt')
               .set('If-None-Match', '"123"')
-              .expect(200, 'tobi', () => t.pass())
+              .expect(200, 'tobi', err => t.error(err))
           })
       })
     })
@@ -886,7 +886,7 @@ test('send(file).pipe(res)', function (t) {
             request(app)
               .get('/name.txt')
               .set('If-Unmodified-Since', res.headers['last-modified'])
-              .expect(200, () => t.pass())
+              .expect(200, err => t.error(err))
           })
       })
 
@@ -913,7 +913,7 @@ test('send(file).pipe(res)', function (t) {
             request(app)
               .get('/name.txt')
               .set('If-Unmodified-Since', date)
-              .expect(412, () => t.pass())
+              .expect(412, err => t.error(err))
           })
       })
 
@@ -934,7 +934,7 @@ test('send(file).pipe(res)', function (t) {
         request(app)
           .get('/name.txt')
           .set('If-Unmodified-Since', 'foo')
-          .expect(200, () => t.pass())
+          .expect(200, err => t.error(err))
       })
     })
   })
@@ -959,7 +959,7 @@ test('send(file).pipe(res)', function (t) {
       request(app)
         .get('/nums.txt')
         .set('Range', 'bytes=0-4')
-        .expect(206, '12345', () => t.pass())
+        .expect(206, '12345', err => t.error(err))
     })
 
     t.test('should ignore non-byte ranges', function (t) {
@@ -979,7 +979,7 @@ test('send(file).pipe(res)', function (t) {
       request(app)
         .get('/nums.txt')
         .set('Range', 'items=0-4')
-        .expect(200, '123456789', () => t.pass())
+        .expect(200, '123456789', err => t.error(err))
     })
 
     t.test('should be inclusive', function (t) {
@@ -999,7 +999,7 @@ test('send(file).pipe(res)', function (t) {
       request(app)
         .get('/nums.txt')
         .set('Range', 'bytes=0-0')
-        .expect(206, '1', () => t.pass())
+        .expect(206, '1', err => t.error(err))
     })
 
     t.test('should set Content-Range', function (t) {
@@ -1020,7 +1020,7 @@ test('send(file).pipe(res)', function (t) {
         .get('/nums.txt')
         .set('Range', 'bytes=2-5')
         .expect('Content-Range', 'bytes 2-5/9')
-        .expect(206, () => t.pass())
+        .expect(206, err => t.error(err))
     })
 
     t.test('should support -n', function (t) {
@@ -1040,7 +1040,7 @@ test('send(file).pipe(res)', function (t) {
       request(app)
         .get('/nums.txt')
         .set('Range', 'bytes=-3')
-        .expect(206, '789', () => t.pass())
+        .expect(206, '789', err => t.error(err))
     })
 
     t.test('should support n-', function (t) {
@@ -1060,7 +1060,7 @@ test('send(file).pipe(res)', function (t) {
       request(app)
         .get('/nums.txt')
         .set('Range', 'bytes=3-')
-        .expect(206, '456789', () => t.pass())
+        .expect(206, '456789', err => t.error(err))
     })
 
     t.test('should respond with 206 "Partial Content"', function (t) {
@@ -1080,7 +1080,7 @@ test('send(file).pipe(res)', function (t) {
       request(app)
         .get('/nums.txt')
         .set('Range', 'bytes=0-4')
-        .expect(206, () => t.pass())
+        .expect(206, err => t.error(err))
     })
 
     t.test('should set Content-Length to the # of octets transferred', function (t) {
@@ -1101,7 +1101,7 @@ test('send(file).pipe(res)', function (t) {
         .get('/nums.txt')
         .set('Range', 'bytes=2-3')
         .expect('Content-Length', '2')
-        .expect(206, '34', () => t.pass())
+        .expect(206, '34', err => t.error(err))
     })
 
     t.test('when last-byte-pos of the range is greater the length', function (t) {
@@ -1125,7 +1125,7 @@ test('send(file).pipe(res)', function (t) {
           .get('/nums.txt')
           .set('Range', 'bytes=2-50')
           .expect('Content-Range', 'bytes 2-8/9')
-          .expect(206, () => t.pass())
+          .expect(206, err => t.error(err))
       })
 
       t.test('should adapt the Content-Length accordingly', function (t) {
@@ -1146,7 +1146,7 @@ test('send(file).pipe(res)', function (t) {
           .get('/nums.txt')
           .set('Range', 'bytes=2-50')
           .expect('Content-Length', '7')
-          .expect(206, () => t.pass())
+          .expect(206, err => t.error(err))
       })
     })
 
@@ -1171,7 +1171,7 @@ test('send(file).pipe(res)', function (t) {
           .get('/nums.txt')
           .set('Range', 'bytes=9-50')
           .expect('Content-Range', 'bytes */9')
-          .expect(416, () => t.pass())
+          .expect(416, err => t.error(err))
       })
 
       t.test('should emit error 416 with content-range header', function (t) {
@@ -1191,7 +1191,7 @@ test('send(file).pipe(res)', function (t) {
           .get('/nums.txt')
           .set('Range', 'bytes=9-50')
           .expect('X-Content-Range', 'bytes */9')
-          .expect(416, () => t.pass())
+          .expect(416, err => t.error(err))
       })
     })
 
@@ -1215,7 +1215,7 @@ test('send(file).pipe(res)', function (t) {
         request(app)
           .get('/nums.txt')
           .set('Range', 'asdf')
-          .expect(200, '123456789', () => t.pass())
+          .expect(200, '123456789', err => t.error(err))
       })
     })
 
@@ -1240,7 +1240,7 @@ test('send(file).pipe(res)', function (t) {
           .get('/nums.txt')
           .set('Range', 'bytes=1-1,3-')
           .expect(shouldNotHaveHeader('Content-Range', t))
-          .expect(200, '123456789', () => t.pass())
+          .expect(200, '123456789', err => t.error(err))
       })
 
       t.test('should respond with 206 is all ranges can be combined', function (t) {
@@ -1261,7 +1261,7 @@ test('send(file).pipe(res)', function (t) {
           .get('/nums.txt')
           .set('Range', 'bytes=1-2,3-5')
           .expect('Content-Range', 'bytes 1-5/9')
-          .expect(206, '23456', () => t.pass())
+          .expect(206, '23456', err => t.error(err))
       })
     })
 
@@ -1292,7 +1292,7 @@ test('send(file).pipe(res)', function (t) {
               .get('/nums.txt')
               .set('If-Range', etag)
               .set('Range', 'bytes=0-0')
-              .expect(206, '1', () => t.pass())
+              .expect(206, '1', err => t.error(err))
           })
       })
 
@@ -1320,7 +1320,7 @@ test('send(file).pipe(res)', function (t) {
               .get('/nums.txt')
               .set('If-Range', etag)
               .set('Range', 'bytes=0-0')
-              .expect(200, '123456789', () => t.pass())
+              .expect(200, '123456789', err => t.error(err))
           })
       })
 
@@ -1348,7 +1348,7 @@ test('send(file).pipe(res)', function (t) {
               .get('/nums.txt')
               .set('If-Range', modified)
               .set('Range', 'bytes=0-0')
-              .expect(206, '1', () => t.pass())
+              .expect(206, '1', err => t.error(err))
           })
       })
 
@@ -1376,7 +1376,7 @@ test('send(file).pipe(res)', function (t) {
               .get('/nums.txt')
               .set('If-Range', new Date(modified).toUTCString())
               .set('Range', 'bytes=0-0')
-              .expect(200, '123456789', () => t.pass())
+              .expect(200, '123456789', err => t.error(err))
           })
       })
 
@@ -1398,7 +1398,7 @@ test('send(file).pipe(res)', function (t) {
           .get('/nums.txt')
           .set('If-Range', 'foo')
           .set('Range', 'bytes=0-0')
-          .expect(200, '123456789', () => t.pass())
+          .expect(200, '123456789', err => t.error(err))
       })
     })
   })
@@ -1411,7 +1411,7 @@ test('send(file).pipe(res)', function (t) {
 
       request(createServer({ root: fixtures, start: 3, end: 5 }))
         .get('/nums.txt')
-        .expect(200, '456', () => t.pass())
+        .expect(200, '456', err => t.error(err))
     })
 
     t.test('should adjust too large end', function (t) {
@@ -1419,7 +1419,7 @@ test('send(file).pipe(res)', function (t) {
 
       request(createServer({ root: fixtures, start: 3, end: 90 }))
         .get('/nums.txt')
-        .expect(200, '456789', () => t.pass())
+        .expect(200, '456789', err => t.error(err))
     })
 
     t.test('should support start/end with Range request', function (t) {
@@ -1428,7 +1428,7 @@ test('send(file).pipe(res)', function (t) {
       request(createServer({ root: fixtures, start: 0, end: 2 }))
         .get('/nums.txt')
         .set('Range', 'bytes=-2')
-        .expect(206, '23', () => t.pass())
+        .expect(206, '23', err => t.error(err))
     })
 
     t.test('should support start/end with unsatisfiable Range request', function (t) {
@@ -1438,7 +1438,7 @@ test('send(file).pipe(res)', function (t) {
         .get('/nums.txt')
         .set('Range', 'bytes=5-9')
         .expect('Content-Range', 'bytes */3')
-        .expect(416, () => t.pass())
+        .expect(416, err => t.error(err))
     })
   })
 
@@ -1457,7 +1457,7 @@ test('send(file).pipe(res)', function (t) {
       request(app)
         .get('/name.txt')
         .expect(shouldNotHaveHeader('ETag', t))
-        .expect(200, () => t.pass())
+        .expect(200, err => t.error(err))
     })
   })
 
@@ -1475,7 +1475,7 @@ test('send(file).pipe(res)', function (t) {
 
       request(app)
         .get('/pets/../name.txt')
-        .expect(200, 'tobi', () => t.pass())
+        .expect(200, 'tobi', err => t.error(err))
     })
   })
 
@@ -1493,7 +1493,7 @@ test('send(file).pipe(res)', function (t) {
 
       request(app)
         .get('/.hidden.txt')
-        .expect(200, 'secret', () => t.pass())
+        .expect(200, 'secret', err => t.error(err))
     })
   })
 
@@ -1511,7 +1511,7 @@ test('send(file).pipe(res)', function (t) {
 
       request(app)
         .get('/')
-        .expect(200, '<p>tobi</p>', () => t.pass())
+        .expect(200, '<p>tobi</p>', err => t.error(err))
     })
 
     t.test('should support disabling', function (t) {
@@ -1525,7 +1525,7 @@ test('send(file).pipe(res)', function (t) {
 
       request(app)
         .get('/pets/')
-        .expect(403, () => t.pass())
+        .expect(403, err => t.error(err))
     })
 
     t.test('should support fallbacks', function (t) {
@@ -1539,7 +1539,7 @@ test('send(file).pipe(res)', function (t) {
 
       request(app)
         .get('/pets/')
-        .expect(200, fs.readFileSync(path.join(fixtures, 'pets', 'index.html'), 'utf8'), () => t.pass())
+        .expect(200, fs.readFileSync(path.join(fixtures, 'pets', 'index.html'), 'utf8'), err => t.error(err))
     })
   })
 
@@ -1557,7 +1557,7 @@ test('send(file).pipe(res)', function (t) {
 
       request(app)
         .get('/name.txt')
-        .expect('Cache-Control', 'public, max-age=0', () => t.pass())
+        .expect('Cache-Control', 'public, max-age=0', err => t.error(err))
     })
 
     t.test('should floor to integer', function (t) {
@@ -1571,7 +1571,7 @@ test('send(file).pipe(res)', function (t) {
 
       request(app)
         .get('/name.txt')
-        .expect('Cache-Control', 'public, max-age=1', () => t.pass())
+        .expect('Cache-Control', 'public, max-age=1', err => t.error(err))
     })
 
     t.test('should accept string', function (t) {
@@ -1585,7 +1585,7 @@ test('send(file).pipe(res)', function (t) {
 
       request(app)
         .get('/name.txt')
-        .expect('Cache-Control', 'public, max-age=2592000', () => t.pass())
+        .expect('Cache-Control', 'public, max-age=2592000', err => t.error(err))
     })
 
     t.test('should max at 1 year', function (t) {
@@ -1599,7 +1599,7 @@ test('send(file).pipe(res)', function (t) {
 
       request(app)
         .get('/name.txt')
-        .expect('Cache-Control', 'public, max-age=31536000', () => t.pass())
+        .expect('Cache-Control', 'public, max-age=31536000', err => t.error(err))
     })
   })
 
@@ -1617,7 +1617,7 @@ test('send(file).pipe(res)', function (t) {
 
       request(app)
         .get('/pets/../name.txt')
-        .expect(200, 'tobi', () => t.pass())
+        .expect(200, 'tobi', err => t.error(err))
     })
   })
 })

--- a/test/send.test.js
+++ b/test/send.test.js
@@ -26,7 +26,7 @@ test('send(file, options)', function (t) {
       request(createServer({ acceptRanges: false, root: fixtures }))
         .get('/nums.txt')
         .expect(shouldNotHaveHeader('Accept-Ranges', t))
-        .expect(200, () => t.pass())
+        .expect(200, err => t.error(err))
     })
 
     t.test('should ignore requested range', function (t) {
@@ -37,7 +37,7 @@ test('send(file, options)', function (t) {
         .set('Range', 'bytes=0-2')
         .expect(shouldNotHaveHeader('Accept-Ranges', t))
         .expect(shouldNotHaveHeader('Content-Range', t))
-        .expect(200, '123456789', () => t.pass())
+        .expect(200, '123456789', err => t.error(err))
     })
   })
 
@@ -49,7 +49,7 @@ test('send(file, options)', function (t) {
       request(createServer({ cacheControl: false, root: fixtures }))
         .get('/name.txt')
         .expect(shouldNotHaveHeader('Cache-Control', t))
-        .expect(200, () => t.pass())
+        .expect(200, err => t.error(err))
     })
 
     t.test('should ignore maxAge option', function (t) {
@@ -58,7 +58,7 @@ test('send(file, options)', function (t) {
       request(createServer({ cacheControl: false, maxAge: 1000, root: fixtures }))
         .get('/name.txt')
         .expect(shouldNotHaveHeader('Cache-Control', t))
-        .expect(200, () => t.pass())
+        .expect(200, err => t.error(err))
     })
   })
 
@@ -71,7 +71,7 @@ test('send(file, options)', function (t) {
       request(createServer({ etag: false, root: fixtures }))
         .get('/name.txt')
         .expect(shouldNotHaveHeader('ETag', t))
-        .expect(200, () => t.pass())
+        .expect(200, err => t.error(err))
     })
   })
 
@@ -83,7 +83,7 @@ test('send(file, options)', function (t) {
 
       request(createServer({ extensions: 42, root: fixtures }))
         .get('/pets/')
-        .expect(500, /TypeError: extensions option/, () => t.pass())
+        .expect(500, /TypeError: extensions option/, err => t.error(err))
     })
 
     t.test('should reject true', function (t) {
@@ -91,7 +91,7 @@ test('send(file, options)', function (t) {
 
       request(createServer({ extensions: true, root: fixtures }))
         .get('/pets/')
-        .expect(500, /TypeError: extensions option/, () => t.pass())
+        .expect(500, /TypeError: extensions option/, err => t.error(err))
     })
 
     t.test('should be not be enabled by default', function (t) {
@@ -99,7 +99,7 @@ test('send(file, options)', function (t) {
 
       request(createServer({ root: fixtures }))
         .get('/tobi')
-        .expect(404, () => t.pass())
+        .expect(404, err => t.error(err))
     })
 
     t.test('should be configurable', function (t) {
@@ -107,7 +107,7 @@ test('send(file, options)', function (t) {
 
       request(createServer({ extensions: 'txt', root: fixtures }))
         .get('/name')
-        .expect(200, 'tobi', () => t.pass())
+        .expect(200, 'tobi', err => t.error(err))
     })
 
     t.test('should support disabling extensions', function (t) {
@@ -115,7 +115,7 @@ test('send(file, options)', function (t) {
 
       request(createServer({ extensions: false, root: fixtures }))
         .get('/name')
-        .expect(404, () => t.pass())
+        .expect(404, err => t.error(err))
     })
 
     t.test('should support fallbacks', function (t) {
@@ -123,7 +123,7 @@ test('send(file, options)', function (t) {
 
       request(createServer({ extensions: ['htm', 'html', 'txt'], root: fixtures }))
         .get('/name')
-        .expect(200, '<p>tobi</p>', () => t.pass())
+        .expect(200, '<p>tobi</p>', err => t.error(err))
     })
 
     t.test('should 404 if nothing found', function (t) {
@@ -131,7 +131,7 @@ test('send(file, options)', function (t) {
 
       request(createServer({ extensions: ['htm', 'html', 'txt'], root: fixtures }))
         .get('/bob')
-        .expect(404, () => t.pass())
+        .expect(404, err => t.error(err))
     })
 
     t.test('should skip directories', function (t) {
@@ -139,7 +139,7 @@ test('send(file, options)', function (t) {
 
       request(createServer({ extensions: ['file', 'dir'], root: fixtures }))
         .get('/name')
-        .expect(404, () => t.pass())
+        .expect(404, err => t.error(err))
     })
 
     t.test('should not search if file has extension', function (t) {
@@ -147,7 +147,7 @@ test('send(file, options)', function (t) {
 
       request(createServer({ extensions: 'html', root: fixtures }))
         .get('/thing.html')
-        .expect(404, () => t.pass())
+        .expect(404, err => t.error(err))
     })
   })
 
@@ -160,7 +160,7 @@ test('send(file, options)', function (t) {
       request(createServer({ lastModified: false, root: fixtures }))
         .get('/name.txt')
         .expect(shouldNotHaveHeader('Last-Modified', t))
-        .expect(200, () => t.pass())
+        .expect(200, err => t.error(err))
     })
   })
 
@@ -172,7 +172,7 @@ test('send(file, options)', function (t) {
 
       request(createServer({ from: fixtures }))
         .get('/pets/../name.txt')
-        .expect(200, 'tobi', () => t.pass())
+        .expect(200, 'tobi', err => t.error(err))
     })
   })
 
@@ -184,7 +184,7 @@ test('send(file, options)', function (t) {
 
       request(createServer({ root: fixtures }))
         .get('/.hidden.txt')
-        .expect(404, () => t.pass())
+        .expect(404, err => t.error(err))
     })
 
     t.test('should allow file within dotfile directory for back-compat', function (t) {
@@ -192,7 +192,7 @@ test('send(file, options)', function (t) {
 
       request(createServer({ root: fixtures }))
         .get('/.mine/name.txt')
-        .expect(200, /tobi/, () => t.pass())
+        .expect(200, /tobi/, err => t.error(err))
     })
 
     t.test('should reject bad value', function (t) {
@@ -200,7 +200,7 @@ test('send(file, options)', function (t) {
 
       request(createServer({ dotfiles: 'bogus' }))
         .get('/name.txt')
-        .expect(500, /dotfiles/, () => t.pass())
+        .expect(500, /dotfiles/, err => t.error(err))
     })
 
     t.test('when "allow"', function (t) {
@@ -210,21 +210,21 @@ test('send(file, options)', function (t) {
         t.plan(1)
         request(createServer({ dotfiles: 'allow', root: fixtures }))
           .get('/.hidden.txt')
-          .expect(200, 'secret', () => t.pass())
+          .expect(200, 'secret', err => t.error(err))
       })
 
       t.test('should send within dotfile directory', function (t) {
         t.plan(1)
         request(createServer({ dotfiles: 'allow', root: fixtures }))
           .get('/.mine/name.txt')
-          .expect(200, /tobi/, () => t.pass())
+          .expect(200, /tobi/, err => t.error(err))
       })
 
       t.test('should 404 for non-existent dotfile', function (t) {
         t.plan(1)
         request(createServer({ dotfiles: 'allow', root: fixtures }))
           .get('/.nothere')
-          .expect(404, () => t.pass())
+          .expect(404, err => t.error(err))
       })
     })
 
@@ -235,63 +235,63 @@ test('send(file, options)', function (t) {
         t.plan(1)
         request(createServer({ dotfiles: 'deny', root: fixtures }))
           .get('/.hidden.txt')
-          .expect(403, () => t.pass())
+          .expect(403, err => t.error(err))
       })
 
       t.test('should 403 for dotfile directory', function (t) {
         t.plan(1)
         request(createServer({ dotfiles: 'deny', root: fixtures }))
           .get('/.mine')
-          .expect(403, () => t.pass())
+          .expect(403, err => t.error(err))
       })
 
       t.test('should 403 for dotfile directory with trailing slash', function (t) {
         t.plan(1)
         request(createServer({ dotfiles: 'deny', root: fixtures }))
           .get('/.mine/')
-          .expect(403, () => t.pass())
+          .expect(403, err => t.error(err))
       })
 
       t.test('should 403 for file within dotfile directory', function (t) {
         t.plan(1)
         request(createServer({ dotfiles: 'deny', root: fixtures }))
           .get('/.mine/name.txt')
-          .expect(403, () => t.pass())
+          .expect(403, err => t.error(err))
       })
 
       t.test('should 403 for non-existent dotfile', function (t) {
         t.plan(1)
         request(createServer({ dotfiles: 'deny', root: fixtures }))
           .get('/.nothere')
-          .expect(403, () => t.pass())
+          .expect(403, err => t.error(err))
       })
 
       t.test('should 403 for non-existent dotfile directory', function (t) {
         t.plan(1)
         request(createServer({ dotfiles: 'deny', root: fixtures }))
           .get('/.what/name.txt')
-          .expect(403, () => t.pass())
+          .expect(403, err => t.error(err))
       })
 
       t.test('should 403 for dotfile in directory', function (t) {
         t.plan(1)
         request(createServer({ dotfiles: 'deny', root: fixtures }))
           .get('/pets/.hidden')
-          .expect(403, () => t.pass())
+          .expect(403, err => t.error(err))
       })
 
       t.test('should 403 for dotfile in dotfile directory', function (t) {
         t.plan(1)
         request(createServer({ dotfiles: 'deny', root: fixtures }))
           .get('/.mine/.hidden')
-          .expect(403, () => t.pass())
+          .expect(403, err => t.error(err))
       })
 
       t.test('should send files in root dotfile directory', function (t) {
         t.plan(1)
         request(createServer({ dotfiles: 'deny', root: path.join(fixtures, '.mine') }))
           .get('/name.txt')
-          .expect(200, /tobi/, () => t.pass())
+          .expect(200, /tobi/, err => t.error(err))
       })
 
       t.test('should 403 for dotfile without root', function (t) {
@@ -302,7 +302,7 @@ test('send(file, options)', function (t) {
 
         request(server)
           .get('/name.txt')
-          .expect(403, () => t.pass())
+          .expect(403, err => t.error(err))
       })
     })
 
@@ -314,7 +314,7 @@ test('send(file, options)', function (t) {
 
         request(createServer({ dotfiles: 'ignore', root: fixtures }))
           .get('/.hidden.txt')
-          .expect(404, () => t.pass())
+          .expect(404, err => t.error(err))
       })
 
       t.test('should 404 for dotfile directory', function (t) {
@@ -322,7 +322,7 @@ test('send(file, options)', function (t) {
 
         request(createServer({ dotfiles: 'ignore', root: fixtures }))
           .get('/.mine')
-          .expect(404, () => t.pass())
+          .expect(404, err => t.error(err))
       })
 
       t.test('should 404 for dotfile directory with trailing slash', function (t) {
@@ -330,7 +330,7 @@ test('send(file, options)', function (t) {
 
         request(createServer({ dotfiles: 'ignore', root: fixtures }))
           .get('/.mine/')
-          .expect(404, () => t.pass())
+          .expect(404, err => t.error(err))
       })
 
       t.test('should 404 for file within dotfile directory', function (t) {
@@ -338,7 +338,7 @@ test('send(file, options)', function (t) {
 
         request(createServer({ dotfiles: 'ignore', root: fixtures }))
           .get('/.mine/name.txt')
-          .expect(404, () => t.pass())
+          .expect(404, err => t.error(err))
       })
 
       t.test('should 404 for non-existent dotfile', function (t) {
@@ -346,7 +346,7 @@ test('send(file, options)', function (t) {
 
         request(createServer({ dotfiles: 'ignore', root: fixtures }))
           .get('/.nothere')
-          .expect(404, () => t.pass())
+          .expect(404, err => t.error(err))
       })
 
       t.test('should 404 for non-existent dotfile directory', function (t) {
@@ -354,7 +354,7 @@ test('send(file, options)', function (t) {
 
         request(createServer({ dotfiles: 'ignore', root: fixtures }))
           .get('/.what/name.txt')
-          .expect(404, () => t.pass())
+          .expect(404, err => t.error(err))
       })
 
       t.test('should send files in root dotfile directory', function (t) {
@@ -362,7 +362,7 @@ test('send(file, options)', function (t) {
 
         request(createServer({ dotfiles: 'ignore', root: path.join(fixtures, '.mine') }))
           .get('/name.txt')
-          .expect(200, /tobi/, () => t.pass())
+          .expect(200, /tobi/, err => t.error(err))
       })
 
       t.test('should 404 for dotfile without root', function (t) {
@@ -374,7 +374,7 @@ test('send(file, options)', function (t) {
 
         request(server)
           .get('/name.txt')
-          .expect(404, () => t.pass())
+          .expect(404, err => t.error(err))
       })
     })
   })
@@ -397,14 +397,14 @@ test('send(file, options)', function (t) {
       })
       request(app)
         .get('/.hidden.txt')
-        .expect(404, 'Not Found', () => t.pass())
+        .expect(404, 'Not Found', err => t.error(err))
     })
 
     t.test('should default support sending hidden files', function (t) {
       t.plan(1)
       request(createServer({ hidden: true, root: fixtures }))
         .get('/.hidden.txt')
-        .expect(200, 'secret', () => t.pass())
+        .expect(200, 'secret', err => t.error(err))
     })
   })
 
@@ -416,7 +416,7 @@ test('send(file, options)', function (t) {
 
       request(createServer({ root: fixtures }))
         .get('/name.txt')
-        .expect('Cache-Control', 'public, max-age=0', () => t.pass())
+        .expect('Cache-Control', 'public, max-age=0', err => t.error(err))
     })
 
     t.test('should set immutable directive in Cache-Control', function (t) {
@@ -424,7 +424,7 @@ test('send(file, options)', function (t) {
 
       request(createServer({ immutable: true, maxAge: '1h', root: fixtures }))
         .get('/name.txt')
-        .expect('Cache-Control', 'public, max-age=3600, immutable', () => t.pass())
+        .expect('Cache-Control', 'public, max-age=3600, immutable', err => t.error(err))
     })
   })
 
@@ -435,28 +435,28 @@ test('send(file, options)', function (t) {
       t.plan(1)
       request(createServer({ root: fixtures }))
         .get('/name.txt')
-        .expect('Cache-Control', 'public, max-age=0', () => t.pass())
+        .expect('Cache-Control', 'public, max-age=0', err => t.error(err))
     })
 
     t.test('should floor to integer', function (t) {
       t.plan(1)
       request(createServer({ maxAge: 123956, root: fixtures }))
         .get('/name.txt')
-        .expect('Cache-Control', 'public, max-age=123', () => t.pass())
+        .expect('Cache-Control', 'public, max-age=123', err => t.error(err))
     })
 
     t.test('should accept string', function (t) {
       t.plan(1)
       request(createServer({ maxAge: '30d', root: fixtures }))
         .get('/name.txt')
-        .expect('Cache-Control', 'public, max-age=2592000', () => t.pass())
+        .expect('Cache-Control', 'public, max-age=2592000', err => t.error(err))
     })
 
     t.test('should max at 1 year', function (t) {
       t.plan(1)
       request(createServer({ maxAge: '2y', root: fixtures }))
         .get('/name.txt')
-        .expect('Cache-Control', 'public, max-age=31536000', () => t.pass())
+        .expect('Cache-Control', 'public, max-age=31536000', err => t.error(err))
     })
   })
 
@@ -468,7 +468,7 @@ test('send(file, options)', function (t) {
 
       request(createServer({ root: fixtures, index: 42 }))
         .get('/pets/')
-        .expect(500, /TypeError: index option/, () => t.pass())
+        .expect(500, /TypeError: index option/, err => t.error(err))
     })
 
     t.test('should reject true', function (t) {
@@ -476,7 +476,7 @@ test('send(file, options)', function (t) {
 
       request(createServer({ root: fixtures, index: true }))
         .get('/pets/')
-        .expect(500, /TypeError: index option/, () => t.pass())
+        .expect(500, /TypeError: index option/, err => t.error(err))
     })
 
     t.test('should default to index.html', function (t) {
@@ -484,7 +484,7 @@ test('send(file, options)', function (t) {
 
       request(createServer({ root: fixtures }))
         .get('/pets/')
-        .expect(fs.readFileSync(path.join(fixtures, 'pets', 'index.html'), 'utf8'), () => t.pass())
+        .expect(fs.readFileSync(path.join(fixtures, 'pets', 'index.html'), 'utf8'), err => t.error(err))
     })
 
     t.test('should be configurable', function (t) {
@@ -492,7 +492,7 @@ test('send(file, options)', function (t) {
 
       request(createServer({ root: fixtures, index: 'tobi.html' }))
         .get('/')
-        .expect(200, '<p>tobi</p>', () => t.pass())
+        .expect(200, '<p>tobi</p>', err => t.error(err))
     })
 
     t.test('should support disabling', function (t) {
@@ -500,7 +500,7 @@ test('send(file, options)', function (t) {
 
       request(createServer({ root: fixtures, index: false }))
         .get('/pets/')
-        .expect(403, () => t.pass())
+        .expect(403, err => t.error(err))
     })
 
     t.test('should support fallbacks', function (t) {
@@ -508,7 +508,7 @@ test('send(file, options)', function (t) {
 
       request(createServer({ root: fixtures, index: ['default.htm', 'index.html'] }))
         .get('/pets/')
-        .expect(200, fs.readFileSync(path.join(fixtures, 'pets', 'index.html'), 'utf8'), () => t.pass())
+        .expect(200, fs.readFileSync(path.join(fixtures, 'pets', 'index.html'), 'utf8'), err => t.error(err))
     })
 
     t.test('should 404 if no index file found (file)', function (t) {
@@ -516,7 +516,7 @@ test('send(file, options)', function (t) {
 
       request(createServer({ root: fixtures, index: 'default.htm' }))
         .get('/pets/')
-        .expect(404, () => t.pass())
+        .expect(404, err => t.error(err))
     })
 
     t.test('should 404 if no index file found (dir)', function (t) {
@@ -524,7 +524,7 @@ test('send(file, options)', function (t) {
 
       request(createServer({ root: fixtures, index: 'pets' }))
         .get('/')
-        .expect(404, () => t.pass())
+        .expect(404, err => t.error(err))
     })
 
     t.test('should not follow directories', function (t) {
@@ -532,7 +532,7 @@ test('send(file, options)', function (t) {
 
       request(createServer({ root: fixtures, index: ['pets', 'name.txt'] }))
         .get('/')
-        .expect(200, 'tobi', () => t.pass())
+        .expect(200, 'tobi', err => t.error(err))
     })
 
     t.test('should work without root', function (t) {
@@ -546,7 +546,7 @@ test('send(file, options)', function (t) {
 
       request(server)
         .get('/')
-        .expect(200, /tobi/, () => t.pass())
+        .expect(200, /tobi/, err => t.error(err))
     })
   })
 
@@ -560,7 +560,7 @@ test('send(file, options)', function (t) {
         t.plan(1)
         request(createServer({ root: fixtures }))
           .get('/pets/../name.txt')
-          .expect(200, 'tobi', () => t.pass())
+          .expect(200, 'tobi', err => t.error(err))
       })
 
       t.test('should work with trailing slash', function (t) {
@@ -573,7 +573,7 @@ test('send(file, options)', function (t) {
 
         request(app)
           .get('/name.txt')
-          .expect(200, 'tobi', () => t.pass())
+          .expect(200, 'tobi', err => t.error(err))
       })
 
       t.test('should work with empty path', function (t) {
@@ -586,7 +586,7 @@ test('send(file, options)', function (t) {
 
         request(app)
           .get('/name.txt')
-          .expect(301, /Redirecting to/, () => t.pass())
+          .expect(301, /Redirecting to/, err => t.error(err))
       })
 
       //
@@ -605,7 +605,7 @@ test('send(file, options)', function (t) {
 
         request(app)
           .get('/')
-          .expect(200, 'tobi', () => t.pass())
+          .expect(200, 'tobi', err => t.error(err))
       })
 
       t.test('should restrict paths to within root', function (t) {
@@ -613,7 +613,7 @@ test('send(file, options)', function (t) {
 
         request(createServer({ root: fixtures }))
           .get('/pets/../../send.js')
-          .expect(403, () => t.pass())
+          .expect(403, err => t.error(err))
       })
 
       t.test('should allow .. in root', function (t) {
@@ -626,7 +626,7 @@ test('send(file, options)', function (t) {
 
         request(app)
           .get('/pets/../../send.js')
-          .expect(403, () => t.pass())
+          .expect(403, err => t.error(err))
       })
 
       t.test('should not allow root transversal', function (t) {
@@ -634,7 +634,7 @@ test('send(file, options)', function (t) {
 
         request(createServer({ root: path.join(fixtures, 'name.d') }))
           .get('/../name.dir/name.txt')
-          .expect(403, () => t.pass())
+          .expect(403, err => t.error(err))
       })
 
       t.test('should not allow root path disclosure', function (t) {
@@ -642,7 +642,7 @@ test('send(file, options)', function (t) {
 
         request(createServer({ root: fixtures }))
           .get('/pets/../../fixtures/name.txt')
-          .expect(403, () => t.pass())
+          .expect(403, err => t.error(err))
       })
     })
 
@@ -659,7 +659,7 @@ test('send(file, options)', function (t) {
 
         request(app)
           .get('/../send.js')
-          .expect(403, () => t.pass())
+          .expect(403, err => t.error(err))
       })
 
       t.test('should still serve files with dots in name', function (t) {
@@ -672,7 +672,7 @@ test('send(file, options)', function (t) {
 
         request(app)
           .get('/do..ts.txt')
-          .expect(200, '...', () => t.pass())
+          .expect(200, '...', err => t.error(err))
       })
     })
   })


### PR DESCRIPTION
The equivalent of Mocha.Done is not t.pass but t.error. So here is the PR handling it properly ;)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
