### PR TITLE
use listenerCount immediatly

### DIFF
--- a/index.js
+++ b/index.js
@@ -260,7 +260,7 @@ SendStream.prototype.maxage = deprecate.function(function maxage (maxAge) {
 
 SendStream.prototype.error = function error (status, err) {
   // emit if listeners instead of responding
-  if (this.listenerCount('error')) {
+  if (this.listenerCount('error') > 0) {
     return this.emit('error', createHttpError(status, err))
   }
 
@@ -465,7 +465,7 @@ SendStream.prototype.isRangeFresh = function isRangeFresh () {
 SendStream.prototype.redirect = function redirect (path) {
   const res = this.res
 
-  if (this.listenerCount('directory')) {
+  if (this.listenerCount('directory') > 0) {
     this.emit('directory', res, path)
     return
   }

--- a/index.js
+++ b/index.js
@@ -251,14 +251,16 @@ SendStream.prototype.maxage = deprecate.function(function maxage (maxAge) {
 /**
  * Emit error with `status`.
  *
+ * @memberof SendStream
  * @param {number} status
  * @param {Error} [err]
+ * @this {Stream}
  * @private
  */
 
 SendStream.prototype.error = function error (status, err) {
   // emit if listeners instead of responding
-  if (hasListeners(this, 'error')) {
+  if (this.listenerCount('error')) {
     return this.emit('error', createHttpError(status, err))
   }
 
@@ -463,7 +465,7 @@ SendStream.prototype.isRangeFresh = function isRangeFresh () {
 SendStream.prototype.redirect = function redirect (path) {
   const res = this.res
 
-  if (hasListeners(this, 'directory')) {
+  if (this.listenerCount('directory')) {
     this.emit('directory', res, path)
     return
   }
@@ -1012,26 +1014,6 @@ function getHeaderNames (res) {
   return typeof res.getHeaderNames !== 'function'
     ? Object.keys(res._headers || {})
     : res.getHeaderNames()
-}
-
-/**
- * Determine if emitter has listeners of a given type.
- *
- * The way to do this check is done three different ways in Node.js >= 0.8
- * so this consolidates them into a minimal set using instance methods.
- *
- * @param {EventEmitter} emitter
- * @param {string} type
- * @returns {boolean}
- * @private
- */
-
-function hasListeners (emitter, type) {
-  const count = typeof emitter.listenerCount !== 'function'
-    ? emitter.listeners(type).length
-    : emitter.listenerCount(type)
-
-  return count > 0
 }
 
 /**


### PR DESCRIPTION
We support node >=14. We dont need some 10 year backwards support.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
