### PR TITLE
remove backwards compatibilty of dotfiles

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,11 +122,6 @@ function SendStream (req, path, options) {
     throw new TypeError('dotfiles option must be "allow", "deny", or "ignore"')
   }
 
-  // legacy support
-  if (opts.dotfiles === undefined) {
-    this._dotfiles = undefined
-  }
-
   this._extensions = opts.extensions !== undefined
     ? normalizeList(opts.extensions, 'extensions option')
     : []
@@ -483,16 +478,8 @@ SendStream.prototype.pipe = function pipe (res) {
 
   // dotfile handling
   if (containsDotFile(parts)) {
-    let access = this._dotfiles
-
-    if (access === undefined) {
-      access = parts[parts.length - 1][0] === '.'
-        ? 'ignore'
-        : 'allow'
-    }
-
-    debug('%s dotfile "%s"', access, path)
-    switch (access) {
+    debug('%s dotfile "%s"', this._dotfiles, path)
+    switch (this._dotfiles) {
       case 'allow':
         break
       case 'deny':

--- a/test/send.test.js
+++ b/test/send.test.js
@@ -163,7 +163,7 @@ test('send(file, options)', function (t) {
   })
 
   t.test('dotfiles', function (t) {
-    t.plan(6)
+    t.plan(5)
 
     t.test('should default to "ignore"', function (t) {
       t.plan(1)
@@ -171,14 +171,6 @@ test('send(file, options)', function (t) {
       request(createServer({ root: fixtures }))
         .get('/.hidden.txt')
         .expect(404, err => t.error(err))
-    })
-
-    t.test('should allow file within dotfile directory for back-compat', function (t) {
-      t.plan(1)
-
-      request(createServer({ root: fixtures }))
-        .get('/.mine/name.txt')
-        .expect(200, /tobi/, err => t.error(err))
     })
 
     t.test('should reject bad value', function (t) {


### PR DESCRIPTION
Removes backwards compatibility with dotfiles.

So basically it seems that send was sending files from folders with dot prefix if dotfiles was not set explicitly to allow or ignore

Before you could expose the bla.yaml file in `/.github/bla.yaml` if dotfiles-options was not set. But with this PR it will be depending of  dotfiles option with default being ignore.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
