### PR TITLE
remove encodeurl

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,6 @@
 const createError = require('http-errors')
 const debug = require('debug')('send')
 const destroy = require('destroy')
-const encodeUrl = require('encodeurl')
 const escapeHtml = require('escape-html')
 const etag = require('etag')
 const fresh = require('fresh')
@@ -405,7 +404,7 @@ SendStream.prototype.redirect = function redirect (path) {
     return
   }
 
-  const loc = encodeUrl(collapseLeadingSlashes(this.path + '/'))
+  const loc = encodeURI(collapseLeadingSlashes(this.path + '/'))
   const doc = createHtmlDocument('Redirecting', 'Redirecting to <a href="' + escapeHtml(loc) + '">' +
     escapeHtml(loc) + '</a>')
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "debug": "^4.3.4",
     "destroy": "1.2.0",
-    "encodeurl": "~1.0.2",
     "escape-html": "~1.0.3",
     "etag": "~1.8.1",
     "fast-decode-uri-component": "^1.0.1",


### PR DESCRIPTION
Native encodeURI ist faster than the package encodeurl. So ripping it out....

```js
'use strict'

const benchmark = require('benchmark')
const encodeurl = require('encodeurl')

const url = 'http://localhost/%20snow.html'
const encoded = '/\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f'

new benchmark.Suite()
  .add('encodeurl', function () { encodeurl(url) }, { minSamples: 100 })
  .add('encodeurl', function () { encodeurl(encoded) }, { minSamples: 100 })
  .add('encodeURI', function () { encodeURI(url) }, { minSamples: 100 })
  .add('encodeURI', function () { encodeURI(encoded) }, { minSamples: 100 })

  .on('cycle', function onCycle(event) { console.log(String(event.target)) })
  .run({ async: false })
```

```sh
node benchmarks/encodeUrl.js
encodeurl x 3,459,417 ops/sec ±0.58% (186 runs sampled)
encodeurl x 1,325,988 ops/sec ±0.48% (187 runs sampled)
encodeURI x 5,864,314 ops/sec ±0.12% (194 runs sampled)
encodeURI x 5,904,443 ops/sec ±3.06% (187 runs sampled)
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
