### PR TITLE
remove etag dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,6 @@
 const createError = require('http-errors')
 const debug = require('node:util').debuglog('send')
 const escapeHtml = require('escape-html')
-const etag = require('etag')
 const fresh = require('fresh')
 const fs = require('fs')
 const mime = require('mime')
@@ -790,9 +789,9 @@ SendStream.prototype.setHeader = function setHeader (path, stat) {
   }
 
   if (this._etag && !res.getHeader('ETag')) {
-    const val = etag(stat)
-    debug('etag %s', val)
-    res.setHeader('ETag', val)
+    const etag = 'W/"' + stat.size.toString(16) + '-' + stat.mtime.getTime().toString(16) + '"'
+    debug('etag %s', etag)
+    res.setHeader('ETag', etag)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   ],
   "dependencies": {
     "escape-html": "~1.0.3",
-    "etag": "~1.8.1",
     "fast-decode-uri-component": "^1.0.1",
     "fresh": "0.5.2",
     "http-errors": "2.0.0",


### PR DESCRIPTION
So basically we dont need the etag dependency because we always pass a fs.Stats object into etag and never set options.weak to true. So we always generate a weak etag from the fs stats object. So it reduces to only this one line. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
