### PR TITLE
replace ms with @lukeed/ms

### DIFF
--- a/lib/SendStream.js
+++ b/lib/SendStream.js
@@ -17,7 +17,7 @@ const decode = require('fast-decode-uri-component')
 const escapeHtml = require('escape-html')
 const fresh = require('fresh')
 const mime = require('mime')
-const ms = require('ms')
+const ms = require('@lukeed/ms')
 const onFinished = require('on-finished')
 
 const { clearHeaders } = require('./clearHeaders')
@@ -133,7 +133,7 @@ function SendStream (req, path, options) {
 
   this._maxage = opts.maxAge || opts.maxage
   this._maxage = typeof this._maxage === 'string'
-    ? ms(this._maxage)
+    ? ms.parse(this._maxage)
     : Number(this._maxage)
   this._maxage = !isNaN(this._maxage)
     ? Math.min(Math.max(0, this._maxage), MAX_MAXAGE)

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "fresh": "0.5.2",
     "http-errors": "2.0.0",
     "mime": "^3.0.0",
-    "ms": "2.1.3",
+    "@lukeed/ms": "^2.0.1",
     "on-finished": "2.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
We use ms of @lukeed in @fastify/jwt for performance reasons, so I prefer that one over the original ms. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
