### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ $ npm test
 This simple example will send a specific file to all requests.
 
 ```js
-var http = require('http')
+var http = require('node:http')
 var send = require('send')
 
 var server = http.createServer(function onRequest (req, res) {
@@ -191,7 +191,7 @@ given directory as the top-level. For example, a request
 `GET /foo.txt` will send back `/www/public/foo.txt`.
 
 ```js
-var http = require('http')
+var http = require('node:http')
 var parseUrl = require('parseurl')
 var send = require('@fastify/send')
 
@@ -206,7 +206,7 @@ server.listen(3000)
 ### Custom file types
 
 ```js
-var http = require('http')
+var http = require('node:http')
 var parseUrl = require('parseurl')
 var send = require('@fastify/send')
 
@@ -232,8 +232,8 @@ This is an example of serving up a structure of directories with a
 custom function to render a listing of a directory.
 
 ```js
-var http = require('http')
-var fs = require('fs')
+var http = require('node:http')
+var fs = require('node:fs')
 var parseUrl = require('parseurl')
 var send = require('@fastify/send')
 
@@ -270,7 +270,7 @@ function directory (res, path) {
 ### Serving from a root directory with custom error-handling
 
 ```js
-var http = require('http')
+var http = require('node:http')
 var parseUrl = require('parseurl')
 var send = require('@fastify/send')
 

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const http = require('http')
+const http = require('node:http')
 const send = require('..')
-const path = require('path')
+const path = require('node:path')
 
 const indexPath = path.join(__dirname, 'index.html')
 

--- a/test/SendStream-pipe.test.js
+++ b/test/SendStream-pipe.test.js
@@ -2,11 +2,11 @@
 
 const { test } = require('tap')
 const after = require('after')
-const http = require('http')
-const path = require('path')
+const http = require('node:http')
+const path = require('node:path')
 const request = require('supertest')
 const SendStream = require('../lib/SendStream')
-const os = require('os')
+const os = require('node:os')
 const { shouldNotHaveBody, createServer, shouldNotHaveHeader } = require('./utils')
 
 const dateRegExp = /^\w{3}, \d+ \w+ \d+ \d+:\d+:\d+ \w+$/

--- a/test/SendStream.test.js
+++ b/test/SendStream.test.js
@@ -1,9 +1,9 @@
 'use strict'
 
 const { test } = require('tap')
-const fs = require('fs')
-const http = require('http')
-const path = require('path')
+const fs = require('node:fs')
+const http = require('node:http')
+const path = require('node:path')
 const request = require('supertest')
 const SendStream = require('..').SendStream
 const { shouldNotHaveHeader, createServer } = require('./utils')

--- a/test/mime.test.js
+++ b/test/mime.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { test } = require('tap')
-const path = require('path')
+const path = require('node:path')
 const request = require('supertest')
 const send = require('..')
 const { shouldNotHaveHeader, createServer } = require('./utils')

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const http = require('http')
+const http = require('node:http')
 const send = require('..')
 
 module.exports.shouldNotHaveHeader = function shouldNotHaveHeader (header, t) {


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
