### PR TITLE
update for Fastify v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   test:
-    uses: fastify/workflows/.github/workflows/plugins-ci.yml@v3
+    uses: fastify/workflows/.github/workflows/plugins-ci.yml@v4.1.0
     with:
       license-check: true
       lint: true

--- a/lib/SendStream.js
+++ b/lib/SendStream.js
@@ -416,13 +416,14 @@ SendStream.prototype.isCachable = function isCachable () {
 
 SendStream.prototype.onStatError = function onStatError (error) {
   // POSIX throws ENAMETOOLONG and ENOTDIR, Windows only ENOENT
-  /* istanbul ignore next */
   switch (error.code) {
+    /* c8 ignore start */
     case 'ENAMETOOLONG':
     case 'ENOTDIR':
     case 'ENOENT':
       this.error(404, error)
       break
+    /* c8 ignore stop */
     default:
       this.error(500, error)
       break

--- a/lib/SendStream.js
+++ b/lib/SendStream.js
@@ -570,10 +570,11 @@ SendStream.prototype.pipe = function pipe (res) {
     containsDotFile(parts)
   ) {
     switch (this._dotfiles) {
-      /* istanbul ignore next: unreachable, because NODE_DEBUG can not be set after process is running */
+      /* c8 ignore start */ /* unreachable, because NODE_DEBUG can not be set after process is running */
       case 0: // 'allow'
         debug('allow dotfile "%s"', path)
         break
+      /* c8 ignore stop */
       case 2: // 'deny'
         debug('deny dotfile "%s"', path)
         this.error(403)

--- a/lib/collapseLeadingSlashes.js
+++ b/lib/collapseLeadingSlashes.js
@@ -19,6 +19,7 @@ function collapseLeadingSlashes (str) {
       return str.slice(i - 1)
     }
   }
+  /* c8 ignore next */
 }
 
 module.exports.collapseLeadingSlashes = collapseLeadingSlashes

--- a/package.json
+++ b/package.json
@@ -25,18 +25,18 @@
     "escape-html": "~1.0.3",
     "fast-decode-uri-component": "^1.0.1",
     "http-errors": "2.0.0",
-    "mime": "^3.0.0",
-    "@lukeed/ms": "^2.0.1"
+    "mime": "^3",
+    "@lukeed/ms": "^2.0.2"
   },
   "devDependencies": {
-    "@fastify/pre-commit": "^2.0.2",
-    "@types/node": "^20.1.0",
+    "@fastify/pre-commit": "^2.1.0",
+    "@types/node": "^20.12.2",
     "after": "0.8.2",
     "benchmark": "^2.1.4",
     "snazzy": "^9.0.0",
-    "standard": "^17.0.0",
+    "standard": "^17.1.0",
     "supertest": "6.3.4",
-    "tap": "^16.3.3",
+    "tap": "^18.7.2",
     "tsd": "^0.31.0"
   },
   "scripts": {

--- a/test/mime.test.js
+++ b/test/mime.test.js
@@ -19,11 +19,11 @@ test('send.mime', function (t) {
   t.test('.default_type', function (t) {
     t.plan(3)
 
-    t.before(function () {
+    t.before(() => {
       this.default_type = send.mime.default_type
     })
 
-    t.afterEach(function () {
+    t.afterEach(() => {
       send.mime.default_type = this.default_type
     })
 


### PR DESCRIPTION
- c8s are necessary for coverage
- mime cannot be upgraded (ESM only)