### PR TITLE
refactor: use lowercase for charset

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ const server = http.createServer(async function onRequest (req, res) {
     // get directory list
     const list = await readdir(metadata.path)
     // render an index for the directory
-    res.writeHead(200, { 'Content-Type': 'text/plain; charset=UTF-8' })
+    res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' })
     res.end(list.join('\n') + '\n')
   } else {
     res.writeHead(statusCode, headers)

--- a/lib/send.js
+++ b/lib/send.js
@@ -396,7 +396,7 @@ function sendError (statusCode, err) {
   const doc = ERROR_RESPONSES[statusCode]
 
   // basic response
-  headers['Content-Type'] = 'text/html; charset=UTF-8'
+  headers['Content-Type'] = 'text/html; charset=utf-8'
   headers['Content-Length'] = doc[1]
   headers['Content-Security-Policy'] = "default-src 'none'"
   headers['X-Content-Type-Options'] = 'nosniff'
@@ -492,7 +492,7 @@ function sendFileDirectly (request, path, stat, options) {
   let type = mime.getType(path) || mime.default_type
   debug('content-type %s', type)
   if (type && isUtf8MimeType(type)) {
-    type += '; charset=UTF-8'
+    type += '; charset=utf-8'
   }
   if (type) {
     headers['Content-Type'] = type
@@ -597,7 +597,7 @@ function sendRedirect (path, options) {
   const doc = createHtmlDocument('Redirecting', 'Redirecting to ' + escapeHtml(loc))
 
   const headers = {}
-  headers['Content-Type'] = 'text/html; charset=UTF-8'
+  headers['Content-Type'] = 'text/html; charset=utf-8'
   headers['Content-Length'] = doc[1]
   headers['Content-Security-Policy'] = "default-src 'none'"
   headers['X-Content-Type-Options'] = 'nosniff'

--- a/test/mime.test.js
+++ b/test/mime.test.js
@@ -33,7 +33,7 @@ test('send.mime', function (t) {
 
       request(createServer({ root: fixtures }))
         .get('/no_ext')
-        .expect('Content-Type', 'text/plain; charset=UTF-8')
+        .expect('Content-Type', 'text/plain; charset=utf-8')
         .expect(200, err => t.error(err))
     })
 

--- a/test/send.2.test.js
+++ b/test/send.2.test.js
@@ -259,12 +259,12 @@ test('send(file)', function (t) {
 
     request(app)
       .get('/name.txt')
-      .expect('Content-Type', 'text/plain; charset=UTF-8')
+      .expect('Content-Type', 'text/plain; charset=utf-8')
       .expect(200, function (err) {
         t.error(err)
         request(app)
           .get('/tobi.html')
-          .expect('Content-Type', 'text/html; charset=UTF-8')
+          .expect('Content-Type', 'text/html; charset=utf-8')
           .expect(200, err => t.error(err))
       })
   })

--- a/test/send.3.test.js
+++ b/test/send.3.test.js
@@ -79,7 +79,7 @@ test('send(file)', function (t) {
       const { statusCode, headers, stream, type, metadata } = await send(req, req.url, { root: fixtures })
       if (type === 'directory') {
         const list = await readdir(metadata.path)
-        res.writeHead(200, { 'Content-Type': 'text/plain; charset=UTF-8' })
+        res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' })
         res.end(list.join('\n') + '\n')
       } else {
         res.writeHead(statusCode, headers)
@@ -89,7 +89,7 @@ test('send(file)', function (t) {
 
     request(app)
       .get('/pets')
-      .expect('Content-Type', 'text/plain; charset=UTF-8')
+      .expect('Content-Type', 'text/plain; charset=utf-8')
       .expect(200, '.hidden\nindex.html\n', err => t.error(err))
   })
 


### PR DESCRIPTION
Whilst the `content-type` response header is case-insensitive, lowercase is preferred, as per [RFC 9110 Section 8.3.1](https://httpwg.org/specs/rfc9110.html#rfc.section.8.3.1).

It's very rare to see any sites using uppercase anymore.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
