### PR TITLE
feat: add  `contentType` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ By default, this library uses the `mime` module to set the `Content-Type`
 of the response based on the file extension of the requested file.
 
 To disable this functionality, set `contentType` to `false`.
-The `Content-Type` header will need to be set manually in this case.
+The `Content-Type` header will need to be set manually if disabled.
 
 ##### dotfiles
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ of the `Range` request header.
 Enable or disable setting `Cache-Control` response header, defaults to
 true. Disabling this will ignore the `immutable` and `maxAge` options.
 
+##### contentType
+
+By default, this library uses the `mime` module to set the `Content-Type`
+of the response based on the file extension of the requested file.
+
+To disable this functionality, set `contentType` to `false`.
+The `Content-Type` header will need to be set manually in this case.
+
 ##### dotfiles
 
 Set how "dotfiles" are treated when encountered. A dotfile is a file

--- a/lib/send.js
+++ b/lib/send.js
@@ -101,6 +101,10 @@ function normalizeOptions (options) {
     ? Boolean(options.cacheControl)
     : true
 
+  const contentType = options.contentType !== undefined
+    ? Boolean(options.contentType)
+    : true
+
   const etag = options.etag !== undefined
     ? Boolean(options.etag)
     : true
@@ -137,6 +141,7 @@ function normalizeOptions (options) {
   return {
     acceptRanges,
     cacheControl,
+    contentType,
     etag,
     dotfiles,
     extensions,
@@ -489,13 +494,15 @@ function sendFileDirectly (request, path, stat, options) {
   }
 
   // set content-type
-  let type = mime.getType(path) || mime.default_type
-  debug('content-type %s', type)
-  if (type && isUtf8MimeType(type)) {
-    type += '; charset=utf-8'
-  }
-  if (type) {
-    headers['Content-Type'] = type
+  if (options.contentType) {
+    let type = mime.getType(path) || mime.default_type
+    debug('content-type %s', type)
+    if (type && isUtf8MimeType(type)) {
+      type += '; charset=utf-8'
+    }
+    if (type) {
+      headers['Content-Type'] = type
+    }
   }
 
   // conditional GET support

--- a/test/send.1.test.js
+++ b/test/send.1.test.js
@@ -13,7 +13,7 @@ const { shouldNotHaveHeader, createServer } = require('./utils')
 const fixtures = path.join(__dirname, 'fixtures')
 
 test('send(file, options)', function (t) {
-  t.plan(10)
+  t.plan(11)
 
   t.test('acceptRanges', function (t) {
     t.plan(2)
@@ -56,6 +56,19 @@ test('send(file, options)', function (t) {
       request(createServer({ cacheControl: false, maxAge: 1000, root: fixtures }))
         .get('/name.txt')
         .expect(shouldNotHaveHeader('Cache-Control', t))
+        .expect(200, err => t.error(err))
+    })
+  })
+
+  t.test('contentType', function (t) {
+    t.plan(1)
+
+    t.test('should support disabling content-type', function (t) {
+      t.plan(2)
+
+      request(createServer({ contentType: false, root: fixtures }))
+        .get('/name.txt')
+        .expect(shouldNotHaveHeader('Content-Type', t))
         .expect(200, err => t.error(err))
     })
   })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -45,6 +45,11 @@ declare namespace send {
     cacheControl?: boolean | undefined;
 
     /**
+     * Enable or disable setting Content-Type response header, defaults to true.
+     */
+    contentType?: boolean | undefined;
+
+    /**
      * Set how "dotfiles" are treated when encountered.
      * A dotfile is a file or directory that begins with a dot (".").
      * Note this check is done on the path itself without checking if the path actually exists on the disk.

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -26,7 +26,7 @@ const req: any = {}
 }
 
 {
-  const result = await send(req, '/test.html', { maxAge: 0, root: __dirname + '/wwwroot' })
+  const result = await send(req, '/test.html', { contentType: true, maxAge: 0, root: __dirname + '/wwwroot' })
 
   expectType<SendResult>(result)
   expectType<number>(result.statusCode)
@@ -34,6 +34,14 @@ const req: any = {}
   expectType<Readable>(result.stream)
 }
 
+{
+  const result = await send(req, '/test.html', { contentType: false, root: __dirname + '/wwwroot' })
+
+  expectType<SendResult>(result)
+  expectType<number>(result.statusCode)
+  expectType<Record<string, string>>(result.headers)
+  expectType<Readable>(result.stream)
+}
 
 const result = await send(req, '/test.html')
 switch (result.type) {


### PR DESCRIPTION
This PR adds the ability to disable the `Content-Type` response header via the `contentType` option.

Whilst the automatic setting of the `Content-Type` response header is great, it's not always right for some edge cases, such as for vendor-specific or proprietary extensions.

Likewise,  [the charset is hardcoded to `utf-8`](https://github.com/fastify/send/blob/6f078bb410d2502de0f7817667e9568e48603b2e/lib/send.js#L494-L496) for `text/plain`, `text/html` and `application/json` files; these types can support more than just utf-8 character encoded content so it'd be nice to get around that.

Related to https://github.com/fastify/fastify-static/issues/480.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
