### PR TITLE
build(deps-dev): replace standard with neostandard

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/fastify/send/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/fastify/send/actions/workflows/ci.yml)
 [![NPM version](https://img.shields.io/npm/v/@fastify/send.svg?style=flat)](https://www.npmjs.com/package/@fastify/send)
-[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://standardjs.com/)
+[![neostandard javascript style](https://img.shields.io/badge/code_style-neostandard-brightgreen?style=flat)](https://github.com/neostandard/neostandard)
 
 Send is a library for streaming files from the file system as an HTTP response
 supporting partial responses (Ranges), conditional-GET negotiation (If-Match,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,6 @@
+'use strict'
+
+module.exports = require('neostandard')({
+  ignores: require('neostandard').resolveIgnoresFromGitignore(),
+  ts: true
+})

--- a/package.json
+++ b/package.json
@@ -37,15 +37,14 @@
     "@types/node": "^22.0.0",
     "after": "0.8.2",
     "benchmark": "^2.1.4",
-    "snazzy": "^9.0.0",
-    "standard": "^17.1.0",
+    "neostandard": "^0.11.9",
     "supertest": "6.3.4",
     "tap": "^21.0.0",
     "tsd": "^0.31.0"
   },
   "scripts": {
-    "lint": "standard | snazzy",
-    "lint:fix": "standard --fix | snazzy",
+    "lint": "eslint",
+    "lint:fix": "eslint --fix",
     "test": "npm run test:unit && npm run test:typescript",
     "test:coverage": "tap --coverage-report=html",
     "test:typescript": "tsd",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,23 +4,23 @@
 
 /// <reference types="node" />
 
-import { Dirent } from "fs";
-import * as stream from "stream";
+import { Dirent } from 'fs'
+import * as stream from 'stream'
 
 /**
  * Create a new SendStream for the given path to send to a res.
  * The req is the Node.js HTTP request and the path is a urlencoded path to send (urlencoded, not the actual file-system path).
  */
-declare function send(req: stream.Readable, path: string, options?: send.SendOptions): Promise<send.SendResult>;
+declare function send (req: stream.Readable, path: string, options?: send.SendOptions): Promise<send.SendResult>
 
-type Send = typeof send;
+type Send = typeof send
 
 declare class Mime {
-  constructor(typeMap: TypeMap, ...mimes: TypeMap[]);
+  constructor (typeMap: TypeMap, ...mimes: TypeMap[])
 
-  getType(path: string): string | null;
-  getExtension(mime: string): string | null;
-  define(typeMap: TypeMap, force?: boolean): void;
+  getType (path: string): string | null
+  getExtension (mime: string): string | null
+  define (typeMap: TypeMap, force?: boolean): void
 }
 
 interface TypeMap {
@@ -28,8 +28,8 @@ interface TypeMap {
 }
 
 declare namespace send {
-  export const mime: Mime;
-  export const isUtf8MimeType: (value: string) => boolean;
+  export const mime: Mime
+  export const isUtf8MimeType: (value: string) => boolean
 
   export interface SendOptions {
     /**
@@ -59,7 +59,7 @@ declare namespace send {
      * 'ignore' Pretend like the dotfile does not exist and 404.
      * The default value is similar to 'ignore', with the exception that this default will not ignore the files within a directory that begins with a dot, for backward-compatibility.
      */
-    dotfiles?: "allow" | "deny" | "ignore" | undefined;
+    dotfiles?: 'allow' | 'deny' | 'ignore' | undefined;
 
     /**
      * Byte offset at which the stream ends, defaults to the length of the file minus 1.
@@ -158,4 +158,4 @@ declare namespace send {
   export { send as default }
 }
 
-export = send;
+export = send

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,11 +1,11 @@
-import { Dirent } from 'fs';
-import { Readable } from 'stream';
-import { expectType } from 'tsd';
-import send, { DirectorySendResult, ErrorSendResult, FileSendResult, SendResult } from '..';
+import { Dirent } from 'fs'
+import { Readable } from 'stream'
+import { expectType } from 'tsd'
+import send, { DirectorySendResult, ErrorSendResult, FileSendResult, SendResult } from '..'
 
 send.mime.define({
   'application/x-my-type': ['x-mt', 'x-mtt']
-});
+})
 
 expectType<(value: string) => boolean>(send.isUtf8MimeType)
 expectType<boolean>(send.isUtf8MimeType('application/json'))
@@ -19,7 +19,7 @@ const req: any = {}
     immutable: true,
     maxAge: 0,
     root: __dirname + '/wwwroot'
-  });
+  })
 
   expectType<SendResult>(result)
   expectType<number>(result.statusCode)

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,5 +1,6 @@
-import { Dirent } from 'fs'
-import { Readable } from 'stream'
+import { Dirent } from 'node:fs'
+import { resolve } from 'node:path'
+import { Readable } from 'node:stream'
 import { expectType } from 'tsd'
 import send, { DirectorySendResult, ErrorSendResult, FileSendResult, SendResult } from '..'
 
@@ -18,7 +19,7 @@ const req: any = {}
     maxContentRangeChunkSize: 10,
     immutable: true,
     maxAge: 0,
-    root: __dirname + '/wwwroot'
+    root: resolve(__dirname, '/wwwroot')
   })
 
   expectType<SendResult>(result)
@@ -28,7 +29,7 @@ const req: any = {}
 }
 
 {
-  const result = await send(req, '/test.html', { contentType: true, maxAge: 0, root: __dirname + '/wwwroot' })
+  const result = await send(req, '/test.html', { contentType: true, maxAge: 0, root: resolve(__dirname, '/wwwroot') })
 
   expectType<SendResult>(result)
   expectType<number>(result.statusCode)
@@ -37,7 +38,7 @@ const req: any = {}
 }
 
 {
-  const result = await send(req, '/test.html', { contentType: false, root: __dirname + '/wwwroot' })
+  const result = await send(req, '/test.html', { contentType: false, root: resolve(__dirname, '/wwwroot') })
 
   expectType<SendResult>(result)
   expectType<number>(result.statusCode)


### PR DESCRIPTION
See https://github.com/fastify/fastify-cors/pull/340. This is a batch PR, so may have some issues. Please review changes.