### PR TITLE
types: use `node:` prefix for builtins

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,8 +4,8 @@
 
 /// <reference types="node" />
 
-import { Dirent } from 'fs'
-import * as stream from 'stream'
+import { Dirent } from 'node:fs'
+import * as stream from 'node:stream'
 
 /**
  * Create a new SendStream for the given path to send to a res.


### PR DESCRIPTION
See https://github.com/fastify/fastify/pull/5896. This is a batch PR, so may have some issues. Please review changes.