### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/node": "^22.0.0",
     "after": "0.8.2",
     "benchmark": "^2.1.4",
+    "eslint": "^9.17.0",
     "neostandard": "^0.12.0",
     "supertest": "6.3.4",
     "tap": "^21.0.0",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.