### PR TITLE
feat: add highWaterMark option

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,13 @@ Serve files relative to `path`.
 Byte offset at which the stream starts, defaults to 0. The start is inclusive,
 meaning `start: 2` will include the 3rd byte in the stream.
 
+##### highWaterMark
+
+When provided, this option sets the maximum number of bytes that the internal 
+buffer will hold before pausing reads from the underlying resource.
+If you omit this option (or pass undefined), Node.js falls back to 
+its built-in default for readable binary streams.
+
 ### .mime
 
 The `mime` export is the global instance of the

--- a/lib/send.js
+++ b/lib/send.js
@@ -142,8 +142,8 @@ function normalizeOptions (options) {
     ? resolve(options.root)
     : null
 
-  const highWaterMark = options.highWaterMark !== undefined
-    ? Number(options.highWaterMark)
+  const highWaterMark = typeof options.highWaterMark === 'number' && Number.isInteger(options.highWaterMark) && options.highWaterMark > 0
+    ? options.highWaterMark
     : null
 
   return {
@@ -590,14 +590,6 @@ function sendFileDirectly (request, path, stat, options) {
       // metadata
       type: 'file',
       metadata: { path, stat }
-    }
-  }
-
-  // Custom highWaterMark
-  if (options.highWaterMark) {
-    if (typeof options.highWaterMark !== 'number' || !Number.isInteger(options.highWaterMark) || options.highWaterMark < 0) {
-      options.highWaterMark = undefined
-      debug('highWaterMark option must be a positive integer; received: %s', options.highWaterMark)
     }
   }
 

--- a/lib/send.js
+++ b/lib/send.js
@@ -142,6 +142,10 @@ function normalizeOptions (options) {
     ? resolve(options.root)
     : null
 
+  const highWaterMark = options.highWaterMark !== undefined
+    ? Number(options.highWaterMark)
+    : null
+
   return {
     acceptRanges,
     cacheControl,
@@ -155,6 +159,7 @@ function normalizeOptions (options) {
     maxage,
     maxContentRangeChunkSize,
     root,
+    highWaterMark,
     start: options.start,
     end: options.end
   }
@@ -588,7 +593,16 @@ function sendFileDirectly (request, path, stat, options) {
     }
   }
 
+  // Custom highWaterMark
+  if (options.highWaterMark) {
+    if (typeof options.highWaterMark !== 'number' || !Number.isInteger(options.highWaterMark) || options.highWaterMark < 0) {
+      options.highWaterMark = undefined
+      debug('highWaterMark option must be a positive integer; received: %s', options.highWaterMark)
+    }
+  }
+
   const stream = fs.createReadStream(path, {
+    highWaterMark: options.highWaterMark,
     start: offset,
     end: Math.max(offset, offset + len - 1)
   })

--- a/lib/send.js
+++ b/lib/send.js
@@ -142,7 +142,7 @@ function normalizeOptions (options) {
     ? resolve(options.root)
     : null
 
-  const highWaterMark = typeof options.highWaterMark === 'number' && Number.isInteger(options.highWaterMark) && options.highWaterMark > 0
+  const highWaterMark = Number.isSafeInteger(options.highWaterMark) && options.highWaterMark > 0
     ? options.highWaterMark
     : null
 

--- a/test/send.1.test.js
+++ b/test/send.1.test.js
@@ -7,6 +7,7 @@ const path = require('node:path')
 const request = require('supertest')
 const { send } = require('..')
 const { shouldNotHaveHeader, createServer } = require('./utils')
+const { getDefaultHighWaterMark } = require('node:stream')
 
 // test server
 
@@ -621,7 +622,8 @@ test('send(file, options)', async function (t) {
       const app = http.createServer(async function (req, res) {
         const { statusCode, headers, stream } = await send(req, req.url, { root: fixtures + '/' })
         res.writeHead(statusCode, headers)
-        t.assert.deepStrictEqual(stream.readableHighWaterMark, 65536)
+        console.log(getDefaultHighWaterMark(false))
+        t.assert.deepStrictEqual(stream.readableHighWaterMark, getDefaultHighWaterMark(false))
         stream.pipe(res)
       })
       await request(app)
@@ -634,7 +636,7 @@ test('send(file, options)', async function (t) {
       const app = http.createServer(async function (req, res) {
         const { statusCode, headers, stream } = await send(req, req.url, { highWaterMark: -54, root: fixtures + '/' })
         res.writeHead(statusCode, headers)
-        t.assert.deepStrictEqual(stream.readableHighWaterMark, 65536)
+        t.assert.deepStrictEqual(stream.readableHighWaterMark, getDefaultHighWaterMark(false))
         stream.pipe(res)
       })
       await request(app)

--- a/test/send.1.test.js
+++ b/test/send.1.test.js
@@ -622,7 +622,6 @@ test('send(file, options)', async function (t) {
       const app = http.createServer(async function (req, res) {
         const { statusCode, headers, stream } = await send(req, req.url, { root: fixtures + '/' })
         res.writeHead(statusCode, headers)
-        console.log(getDefaultHighWaterMark(false))
         t.assert.deepStrictEqual(stream.readableHighWaterMark, getDefaultHighWaterMark(false))
         stream.pipe(res)
       })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -120,6 +120,12 @@ declare namespace send {
      * The start is inclusive, meaning start: 2 will include the 3rd byte in the stream.
      */
     start?: number | undefined;
+
+    /**
+     * Maximum number of bytes that the internal buffer will hold.
+     * If omitted, Node.js falls back to its built-in default.
+     */
+    highWaterMark?: number | undefined;
   }
 
   export interface BaseSendResult {


### PR DESCRIPTION
#### Description

- Allow to specify highWaterMark when using send()

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
