### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ application or framework.
 
 This is a [Node.js](https://nodejs.org/en/) module available through the
 [npm registry](https://www.npmjs.com/). Installation is done using the
-[`npm install` command](https://docs.npmjs.com/getting-started/installing-npm-packages-locally):
+[`npm install` command](https://docs.npmjs.com/downloading-and-installing-packages-locally):
 
 ```bash
 $ npm install @fastify/send
@@ -119,7 +119,7 @@ system's last modified value.
 
 Provide a max-age in milliseconds for HTTP caching, defaults to 0.
 This can also be a string accepted by the
-[ms](https://www.npmjs.org/package/ms#readme) module.
+[ms](https://www.npmjs.com/package/ms) module.
 
 ##### maxContentRangeChunkSize
 

--- a/lib/send.js
+++ b/lib/send.js
@@ -240,7 +240,7 @@ function isConditionalGET (request) {
 function isNotModifiedFailure (request, headers) {
   // Always return stale when Cache-Control: no-cache
   // to support end-to-end reload requests
-  // https://tools.ietf.org/html/rfc2616#section-14.9.4
+  // https://datatracker.ietf.org/doc/html/rfc2616#section-14.9.4
   if (
     'cache-control' in request.headers &&
     request.headers['cache-control'].indexOf('no-cache') !== -1


### PR DESCRIPTION
Fixes 404s, 3xx redirections, and missing fragments in the documentation. Part of general link cleanup being tracked in https://github.com/fastify/accept-negotiator/pull/71